### PR TITLE
static modal where the only option is close, not clicking the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         </div>
         </section>
 
-        <div id="alert-modal" class="modal fade">
+        <div class="modal fade" id="alert-modal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
             <div class="modal-dialog">
               <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
Updated the html on the modal so it is static (Bootstrap 5) and it can only close on close button, not clicking back on the page.